### PR TITLE
Differentiate between rubocop severities

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,11 @@ class Rubocop(Linter):
 
     syntax = ('ruby', 'ruby on rails', 'rspec', 'html (rails)')
     cmd = 'rubocop --format emacs'
-    regex = r'^.+?:(?P<line>\d+):(?P<col>\d+): .+?: (?P<message>.+)'
+    regex = (
+        r'^.+?:(?P<line>\d+):(?P<col>\d+): '
+        r'(:?(?P<warning>[RCW])|(?P<error>[EF])): '
+        r'(?P<message>.+)'
+    )
     selectors = {'html (rails)': 'source.ruby.rails.embedded.html'}
     tempfile_suffix = 'rb'
     config_file = ('--config', '.rubocop.yml')


### PR DESCRIPTION
Everything is being highlighted as errors. It would be nice to differentiate between the severities that rubocop has.

I separated them like this:
- Severities [:refactor, :convention, :warning] are highlighted as warnings.
- Severities [:error, :fatal] are highlighted as errors.
