### PR TITLE
Fixes broken repository link

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -7,4 +7,4 @@ This linter plugin for SublimeLinter provides an interface to rubocop.
 Before this plugin will activate, you *must*
 follow the installation instructions here:
 
-https://github.com/Aparajita/SublimeLinter-rubocop
+https://github.com/SublimeLinter/SublimeLinter-rubocop


### PR DESCRIPTION
After installation, I was told to follow instructions on a repository that no longer exists. 
