### PR TITLE
Bundle exec so that all dependant libraries are available

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Rubocop(Linter):
     """Provides an interface to rubocop."""
 
     syntax = ('ruby', 'ruby on rails', 'rspec')
-    cmd = 'rubocop --format emacs'
+    cmd = 'bundle exec rubocop --format emacs'
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.15.0'


### PR DESCRIPTION
Using bundler means you run the version of rubocop specified in your Gemfile.

It also avoids an error I was getting where rubocop-rspec wasn't installed globally.