### PR TITLE
Use RubyLinter as superclass for Rubocop

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,15 +10,15 @@
 
 """This module exports the Rubocop plugin class."""
 
-from SublimeLinter.lint import Linter
+from SublimeLinter.lint import RubyLinter
 
 
-class Rubocop(Linter):
+class Rubocop(RubyLinter):
 
     """Provides an interface to rubocop."""
 
     syntax = ('ruby', 'ruby on rails', 'rspec')
-    cmd = 'rubocop --format emacs'
+    cmd = 'ruby -S rubocop --format emacs'
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.15.0'

--- a/messages.json
+++ b/messages.json
@@ -3,5 +3,6 @@
     "1.0.5": "messages/1.0.5.txt",
     "1.0.6": "messages/1.0.6.txt",
     "1.0.7": "messages/1.0.7.txt",
-    "1.0.8": "messages/1.0.8.txt"
+    "1.0.8": "messages/1.0.8.txt",
+    "1.0.9": "messages/1.0.9.txt"
 }

--- a/messages/1.0.9.txt
+++ b/messages/1.0.9.txt
@@ -1,0 +1,3 @@
+SublimeLinter-rubocop 1.0.9
+----------------------------
+- Use RubyLinter to help find the ruby we should be running. Should work on wider variety of ruby setups.


### PR DESCRIPTION
Builds from #14 but asks ruby to find rubocop to work with rvm with gemsets.