### PR TITLE
Add support for RubyNext and RubyExperimental

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Rubocop(RubyLinter):
 
     """Provides an interface to rubocop."""
 
-    syntax = ('ruby', 'ruby on rails', 'rspec')
+    syntax = ('ruby', 'ruby on rails', 'rspec', 'betterruby', 'ruby experimental')
     cmd = 'ruby -S rubocop --format emacs'
     version_args = '-S rubocop --version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
Adds support for linting .rb files opened as the [RubyNext](https://gist.github.com/edubkendo/6198986) and [Experimental Ruby](https://github.com/subtleGradient/subtlegradient.tmbundle) syntax types.
