### PR TITLE
Add linting of Cucumber Steps syntax files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SublimeLinter-rubocop
 
 [![Build Status](https://travis-ci.org/SublimeLinter/SublimeLinter-rubocop.svg?branch=master)](https://travis-ci.org/SublimeLinter/SublimeLinter-rubocop)
 
-This linter plugin for [SublimeLinter](http://sublimelinter.readthedocs.org) provides an interface to [rubocop](https://github.com/bbatsov/rubocop). It will be used with files that have the `ruby`, `ruby on rails`, `rspec`, `betterruby` or `ruby experimental` syntaxes.
+This linter plugin for [SublimeLinter](http://sublimelinter.readthedocs.org) provides an interface to [rubocop](https://github.com/bbatsov/rubocop). It will be used with files that have the `ruby`, `ruby on rails`, `rspec`, `betterruby`, `ruby experimental` or `cucumber steps` syntaxes.
 
 ## Installation
 SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 3 is not installed, please follow the instructions [here](http://sublimelinter.readthedocs.org/en/latest/installation.html).

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Rubocop(RubyLinter):
 
     """Provides an interface to rubocop."""
 
-    syntax = ('ruby', 'ruby on rails', 'rspec', 'betterruby', 'ruby experimental')
+    syntax = ('ruby', 'ruby on rails', 'rspec', 'betterruby', 'ruby experimental', 'cucumber steps')
     cmd = 'ruby -S rubocop --format emacs'
     version_args = '-S rubocop --version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
Cucumber Steps files (syntax provided by the Cucumber package) contain a lot of Ruby code, and should therefore be lintable with Rubocop.