### PR TITLE
Mark "Better RSpec" as a rubocop lintable syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SublimeLinter-rubocop
 
 [![Build Status](https://travis-ci.org/SublimeLinter/SublimeLinter-rubocop.svg?branch=master)](https://travis-ci.org/SublimeLinter/SublimeLinter-rubocop)
 
-This linter plugin for [SublimeLinter](http://sublimelinter.readthedocs.org) provides an interface to [rubocop](https://github.com/bbatsov/rubocop). It will be used with files that have the `ruby`, `ruby on rails`, `rspec`, `betterruby`, `ruby experimental` or `cucumber steps` syntaxes.
+This linter plugin for [SublimeLinter](http://sublimelinter.readthedocs.org) provides an interface to [rubocop](https://github.com/bbatsov/rubocop). It will be used with files that have the `ruby`, `ruby on rails`, `rspec`, `better rspec`, `betterruby`, `ruby experimental` or `cucumber steps` syntaxes.
 
 ## Installation
 SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 3 is not installed, please follow the instructions [here](http://sublimelinter.readthedocs.org/en/latest/installation.html).

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,15 @@ class Rubocop(RubyLinter):
 
     """Provides an interface to rubocop."""
 
-    syntax = ('ruby', 'ruby on rails', 'rspec', 'betterruby', 'ruby experimental', 'cucumber steps')
+    syntax = (
+        'ruby',
+        'ruby on rails',
+        'rspec',
+        'betterruby',
+        'better rspec',
+        'ruby experimental',
+        'cucumber steps'
+    )
     cmd = 'ruby -S rubocop --format emacs'
     version_args = '-S rubocop --version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
The files marked as Syntax "Better RSpec" were ignored before. 
See https://github.com/fnando/better-rspec-for-sublime-text to get information about "Better RSpec"

I'm a bit unsure about downcasing and the <space> in "better rspec". When I select the syntax sublime shows "Better RSpec" in the bottom-right corner.