### PR TITLE
Lint files in their original location

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -35,5 +35,5 @@ class Rubocop(RubyLinter):
         r'(:?(?P<warning>[RCW])|(?P<error>[EF])): '
         r'(?P<message>.+)'
     )
-    tempfile_suffix = 'rb'
+    tempfile_suffix = '-'
     config_file = ('--config', '.rubocop.yml')


### PR DESCRIPTION
Rubocop rules are location-specific, so we should lint files in their original locations rather than in temporary directories.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sublimelinter/sublimelinter-rubocop/27)
<!-- Reviewable:end -->
