### PR TITLE
Better path handling by using --stdin, and guessing unsaved file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Before using this plugin, you must ensure that `rubocop` is installed on your sy
 
 1. If you are using `rvm` or `rbenv`, ensure that they are loaded in your shell’s correct startup file. See [here](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#shell-startup-files) for more information.
 
-**Note:** This plugin requires `rubocop` 0.15.0 or later.
+**Note:** This plugin requires `rubocop` 0.34.0 or later.
 
 ### Linter configuration
 In order for `rubocop` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in [“Finding a linter executable”](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation.

--- a/linter.py
+++ b/linter.py
@@ -26,7 +26,8 @@ class Rubocop(RubyLinter):
         'ruby on rails',
         'ruby'
     )
-    cmd = 'ruby -S rubocop --format emacs'
+    cmd = None
+    executable = 'ruby'
     version_args = '-S rubocop --version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.34.0'
@@ -35,5 +36,18 @@ class Rubocop(RubyLinter):
         r'(:?(?P<warning>[RCW])|(?P<error>[EF])): '
         r'(?P<message>.+)'
     )
-    tempfile_suffix = 'rb'
-    config_file = ('--config', '.rubocop.yml')
+
+    def cmd(self):
+        command = ['ruby', '-S', 'rubocop', '--format', 'emacs']
+
+        if self.filename:
+            # Ensure the files contents are passed in via STDIN:
+            self.tempfile_suffix = None
+            command += ['--stdin', path]
+        else:
+            # File is unsaved, instead set tempfile_suffix so that a tempfile is
+            # passed into rubocop, rather than using STDIN (which won't work
+            # when we can't provide a hint as to the files whereabouts):
+            self.tempfile_suffix = 'rb'
+
+        return command

--- a/linter.py
+++ b/linter.py
@@ -39,6 +39,8 @@ class Rubocop(RubyLinter):
     )
 
     def cmd(self):
+        """Build command, using STDIN if a file path can be determined."""
+
         command = ['ruby', '-S', 'rubocop', '--format', 'emacs']
 
         # Set tempfile_suffix so by default a tempfile is passed onto rubocop:

--- a/linter.py
+++ b/linter.py
@@ -40,7 +40,6 @@ class Rubocop(RubyLinter):
 
     def cmd(self):
         """Build command, using STDIN if a file path can be determined."""
-
         command = ['ruby', '-S', 'rubocop', '--format', 'emacs']
 
         # Set tempfile_suffix so by default a tempfile is passed onto rubocop:
@@ -64,8 +63,8 @@ class Rubocop(RubyLinter):
 
         if path:
             # With this path we can instead pass the file contents in via STDIN
-            # and then tell rubocop to use this path (to search for config files
-            # and to use for matching against configured paths - i.e. for
+            # and then tell rubocop to use this path (to search for config
+            # files and to use for matching against configured paths - i.e. for
             # inheritance, inclusions and exclusions):
             command += ['--stdin', path]
             # Ensure the files contents are passed in via STDIN:

--- a/linter.py
+++ b/linter.py
@@ -3,7 +3,7 @@
 # Linter for SublimeLinter3, a code checking framework for Sublime Text 3
 #
 # Written by Aparajita Fishman
-# Contributors: Francis Gulotta, Josh Hagins
+# Contributors: Francis Gulotta, Josh Hagins, Mark Haylock
 # Copyright (c) 2013 Aparajita Fishman
 #
 # License: MIT
@@ -29,7 +29,7 @@ class Rubocop(RubyLinter):
     cmd = 'ruby -S rubocop --format emacs'
     version_args = '-S rubocop --version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 0.15.0'
+    version_requirement = '>= 0.34.0'
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '
         r'(:?(?P<warning>[RCW])|(?P<error>[EF])): '


### PR DESCRIPTION
This PR is 100% inspired by @mattbrictson's [comment](https://github.com/SublimeLinter/SublimeLinter-rubocop/issues/10#issuecomment-193899845) on Issue #10.

I've taken his suggestion to use Rubocop's `--stdin` option and implemented the following:
* Increased the required version of Rubocop to 0.34.0 and above, as this is the first version to [add support for the `--stdin` option](https://github.com/bbatsov/rubocop/pull/2146).
* Where a path for the file can be determined the linter now calls rubocop with `--stdin` and does not use a tempfile (instead the file's current contents are passed in via STDIN).
* For new, unsaved files if a project path can be determined (based on the currently open folders for the views window) then this path is used, otherwise it falls back to the old approach of using a tempfile.

That last change means that if you create a new file it is no longer always linted with the default rubocop config, it will use the projects rubocop config (or at least those in the root of the project) if possible.

In my testing these changes mean there are no longer any issues with relative paths when used for `inherit_from`, `Include` or `Exclude`. Also contextual cops now work, so this fixes #10.

This will also make #27 unnecessary, and thankfully means that unsaved changes can still be linted.