### PR TITLE
Ensure global exclusions are honored

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -65,8 +65,11 @@ class Rubocop(RubyLinter):
             # With this path we can instead pass the file contents in via STDIN
             # and then tell rubocop to use this path (to search for config
             # files and to use for matching against configured paths - i.e. for
-            # inheritance, inclusions and exclusions):
-            command += ['--stdin', path]
+            # inheritance, inclusions and exclusions).
+            #
+            # The 'force-exclusion' overrides rubocop's behavior of ignoring
+            # global excludes when the file path is explicitly provided:
+            command += ['--force-exclusion', '--stdin', path]
             # Ensure the files contents are passed in via STDIN:
             self.tempfile_suffix = None
 


### PR DESCRIPTION
Something I overlooked with #29 is that rubocop by default ignores global exclusions if the file path has been explicitly provided, this is not the behaviour we want for editor linting.

I found [this comment](https://github.com/bbatsov/rubocop/issues/2492#issuecomment-164375887) which highlights that `--force-exclusion` gives us the behaviour we want, so this PR adds that to the arguments passed into rubocop.

I specifically saw a problem on a project where I had the following in `.rubocop.yml`:
```
AllCops:
  Exclude:
    - 'db/schema.rb'
```

And when opening `db/schema.rb` I was seeing that rubocop was still listing the file. Testing locally, the changes in this PR fix that.