### PR TITLE
add new config option `use_bundle_exec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ By default, the linter plugin looks for a config file called `.rubocop.yml` in t
 }
 ```
 
+If you are using Bundler and would like to use the locked rubocop version (which will also allow you to use `inherit_gem` in `rubocop.yml`, in case you are inheriting from another gem in the project), you must set `use_bundle_exec` to true:
+
+```json
+"rubocop": {
+    "use_bundle_exec": true
+}
+```
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 

--- a/linter.py
+++ b/linter.py
@@ -41,7 +41,14 @@ class Rubocop(RubyLinter):
 
     def cmd(self):
         """Build command, using STDIN if a file path can be determined."""
-        command = ['ruby', '-S', 'rubocop', '--format', 'emacs']
+
+        settings = self.get_view_settings()
+        command = ['ruby', '-S']
+
+        if settings.get('use_bundle_exec', False):
+            command.extend(['bundle', 'exec'])
+
+        command.extend(['rubocop', '--format', 'emacs'])
 
         # Set tempfile_suffix so by default a tempfile is passed onto rubocop:
         self.tempfile_suffix = 'rb'


### PR DESCRIPTION
Adds new configuration option: `use_bundle_exec`

Rationale:
1. Ensure a single rubocop version is used among different machines, as it is unlikely that all people working on a project have the same global rubocop version installed.

2. We have a gem within our project, from which we want to inherit rubocop configuration from. Without `bundle exec`, rubocop fails as it can't "see" this gem (unless it is also globally installed).
