### PR TITLE
Change deprecated executable_path call

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -29,7 +29,6 @@ class Rubocop(RubyLinter):
         'ruby'
     )
     cmd = None
-    executable = 'ruby'
     version_args = '-S rubocop --version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.34.0'
@@ -45,8 +44,6 @@ class Rubocop(RubyLinter):
         settings = self.get_view_settings()
 
         command = ['ruby', '-S']
-        if self.executable_path:
-            command = self.executable_path + ['-S']
 
         if settings.get('use_bundle_exec', False):
             command.extend(['bundle', 'exec'])


### PR DESCRIPTION
Fixes https://github.com/SublimeLinter/SublimeLinter-rubocop/issues/51

However if I understand correctly the changes referred in above issue, maybe it would be better to stop using `self.executable` as well and just define `command = ['ruby', '-S']` (as well as removing `executable = 'ruby'` on line 32 https://github.com/SublimeLinter/SublimeLinter-rubocop/blob/master/linter.py#L32 )
Let me know if you want me to make this change.