### PR TITLE
Define a minimal new RubyLinter

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -14,7 +14,7 @@ class RubyLinter(Linter):
         if settings.get('use_bundle_exec', False):
             return True, ['bundle', 'exec', gem_name]
 
-        return True, [gem_name, ]  # Avoid testing if `gem_name` is on PATH
+        return True, gem_name  # Avoid testing if `gem_name` is on PATH
 
 
 class Rubocop(RubyLinter):

--- a/linter.py
+++ b/linter.py
@@ -1,58 +1,32 @@
-import os
-from SublimeLinter.lint import RubyLinter
+from SublimeLinter.lint import Linter
+
+
+class RubyLinter(Linter):
+    def context_sensitive_executable_path(self, cmd):
+        # The default implementation will look for a user defined `executable`
+        # setting.
+        success, executable = super().context_sensitive_executable_path(cmd)
+        if success:
+            return True, executable
+
+        settings = self.get_view_settings()
+        gem_name = cmd[0]
+        if settings.get('use_bundle_exec', False):
+            return True, ['bundle', 'exec', gem_name]
+
+        return True, [gem_name, ]  # Avoid testing if `gem_name` is on PATH
 
 
 class Rubocop(RubyLinter):
-    defaults = {
-        'selector': 'source.ruby - text.html - text.haml'
-    }
+    cmd = ['rubocop', '--format', 'emacs', '--force-exclusion', '${args}']
+
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '
         r'(:?(?P<warning>[RCW])|(?P<error>[EF])): '
         r'(?P<message>.+)'
     )
 
-    def cmd(self):
-        """Build command, using STDIN if a file path can be determined."""
-
-        settings = self.get_view_settings()
-
-        command = ['ruby', '-S']
-
-        if settings.get('use_bundle_exec', False):
-            command.extend(['bundle', 'exec'])
-
-        command.extend(['rubocop', '--format', 'emacs'])
-
-        # Set tempfile_suffix so by default a tempfile is passed onto rubocop:
-        self.tempfile_suffix = 'rb'
-
-        path = self.filename
-        if not path:
-            # File is unsaved, and by default unsaved files use the default
-            # rubocop config because they do not technically belong to a folder
-            # that might contain a custom .rubocop.yml. This means the lint
-            # results may not match the rules for the currently open project.
-            #
-            # If the current window has open folders then we can use the
-            # first open folder as a best-guess for the current projects
-            # root folder - we can then pretend that this unsaved file is
-            # inside this root folder, and rubocop will pick up on any
-            # config file if it does exist:
-            folders = self.view.window().folders()
-            if folders:
-                path = os.path.join(folders[0], 'untitled.rb')
-
-        if path:
-            # With this path we can instead pass the file contents in via STDIN
-            # and then tell rubocop to use this path (to search for config
-            # files and to use for matching against configured paths - i.e. for
-            # inheritance, inclusions and exclusions).
-            #
-            # The 'force-exclusion' overrides rubocop's behavior of ignoring
-            # global excludes when the file path is explicitly provided:
-            command += ['--force-exclusion', '--stdin', path]
-            # Ensure the files contents are passed in via STDIN:
-            self.tempfile_suffix = None
-
-        return command
+    defaults = {
+        'selector': 'source.ruby - text.html - text.haml',
+        '--stdin:': '${file_path:$folder}'
+    }


### PR DESCRIPTION
Experiment: Define a new RubyLinter. 

Given a `cmd` like `rubocop --stdin ...` it will by default assume `rubocop` is available on PATH and just execute it. If you set `use_bundle_exec` it will instead run `bundle exec rubocop --stdin ...` 

A user can set `executable`. E.g. `here/is/my/rubocop` or `['here/is/ruby', '-s', 'rubocop']` in the linter settings.

The runtime env can be modified using the linter setting. E.g.

```
  "linters": {
     "rubocop": {
        "disable": false,
		// "executable": ...
		"env": {
			"PATH": "gems/bin/:$PATH"
		}

```