### PR TITLE
Moved syntax attribute to use 'defaults'

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -3,15 +3,9 @@ from SublimeLinter.lint import RubyLinter
 
 
 class Rubocop(RubyLinter):
-    syntax = (
-        'better rspec',
-        'betterruby',
-        'cucumber steps',
-        'rspec',
-        'ruby experimental',
-        'ruby on rails',
-        'ruby'
-    )
+    defaults = {
+        'selector': 'source.ruby'
+    }
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '
         r'(:?(?P<warning>[RCW])|(?P<error>[EF])): '


### PR DESCRIPTION
Addresses #58 by replacing the `syntax` attribute with a `selector` within the defaults attribute as defined here: http://www.sublimelinter.com/en/stable/linter_settings.html#selector