### PR TITLE
Try to infer rubocop config

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,6 +2,7 @@ import os
 import os.path
 from SublimeLinter.lint import Linter
 
+
 class RubyLinter(Linter):
     def context_sensitive_executable_path(self, cmd):
         # The default implementation will look for a user defined `executable`
@@ -85,8 +86,7 @@ class Rubocop(RubyLinter):
             return file_path
 
         parent_path = os.path.abspath(os.path.join(path, os.pardir))
-        if parent_path == path: # we have reached the root without success
+        if parent_path == path:  # we have reached the root without success
             return None
 
         self._find_file_in_parents(parent_path, filename)
-

--- a/linter.py
+++ b/linter.py
@@ -89,4 +89,4 @@ class Rubocop(RubyLinter):
         if parent_path == path:  # we have reached the root without success
             return None
 
-        self._find_file_in_parents(parent_path, filename)
+        return self._find_file_in_parents(parent_path, filename)


### PR DESCRIPTION
Since we are using the STDIN to pipe the contents of the editor in rubocop can not infer the path of the `.rubocopo.yml` within the current project. It falls back to the user's default (in home dir).
Hence, I added a little snippet which tries to find the config.

Also see Rubocop's [config path logic](https://docs.rubocop.org/rubocop/configuration.html#config-file-locations).