### PR TITLE
Fix regex

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -29,13 +29,15 @@ class Rubocop(RubyLinter):
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '
         r'(:?(?P<warning>[RCW])|(?P<error>[EF])): '
-        r'(?P<message>.+)'
+        r'(?P<fixable>\[Correctable\] )?'
+        r'((?P<code>\w+/\w+): )?'
+        r'(?P<message>.+)$'
     )
 
     def cmd(self):
         """Build command, using STDIN if a file path can be determined."""
 
-        command = ['rubocop', '--format', 'emacs']
+        command = ['rubocop', '--format', 'emacs', '--display-cop-names']
 
         path = self.filename
         if not path:


### PR DESCRIPTION
I noticed that the message given by Sublime Linter with Rubocop in the popup was not as great as it could be:

<img width="969" alt="old" src="https://user-images.githubusercontent.com/190479/109371891-cd7fe480-785b-11eb-8d4a-ef47994cb944.png">

This PR fixes it:

<img width="955" alt="new" src="https://user-images.githubusercontent.com/190479/109372043-497a2c80-785c-11eb-8c79-abc8a9b612a0.png">

The new regexp is the following: 
`^.+?:(?P<line>\d+):(?P<col>\d+): (:?(?P<warning>[RCW])|(?P<error>[EF])): (?P<fixable>\[Correctable\] )?((?P<code>[A-Za-z]+/[A-Za-z]+): )?(?P<message>.+)$`

I used [this Pythex](https://pythex.org/?regex=%5E.%2B%3F%3A(%3FP%3Cline%3E%5Cd%2B)%3A(%3FP%3Ccol%3E%5Cd%2B)%3A%20(%3A%3F(%3FP%3Cwarning%3E%5BRCW%5D)%7C(%3FP%3Cerror%3E%5BEF%5D))%3A%20(%3FP%3Cfixable%3E%5C%5BCorrectable%5C%5D%20)%3F((%3FP%3Ccode%3E%5BA-Za-z%5D%2B%2F%5BA-Za-z%5D%2B)%3A%20)%3F(%3FP%3Cmessage%3E.%2B)%24&test_string=file.rb%3A127%3A58%3A%20C%3A%20%5BCorrectable%5D%20Layout%2FHashAlignment%3A%20Align%20the%20keys%20and%20values%20of%20a%20hash%20literal%20if%20they%20span%20more%20than%20one%20line.%0Afile.rb%3A76%3A1%3A%20E%3A%20Lint%2FSyntax%3A%20unexpected%20token%20%24end%20(Using%20Ruby%202.7%20parser%3B%20configure%20using%20%60TargetRubyVersion%60%20parameter%2C%20under%20%60AllCops%60)%0Afile.rb%3A128%3A58%3A%20C%3A%20%5BCorrectable%5D%20Align%20the%20keys%20and%20values%20of%20a%20hash%20literal%20if%20they%20span%20more%20than%20one%20line.&ignorecase=0&multiline=1&dotall=0&verbose=0) to help building the regular expression.

Now the Cop Name is used as `code` (instead of `severity`). Severity is already indicated with the type of icon (`warning` or `error`). If somehow the Cop Name is not available, it will still work and behave as the former RegExp (see example 3 on Pythex).

Note: It will also help getting quick action released for Rubocop, as the new RegExp properly label `code`.